### PR TITLE
Include JSON::PP for some vendors

### DIFF
--- a/src/main/perl/make-ddclient-exe.bat
+++ b/src/main/perl/make-ddclient-exe.bat
@@ -23,7 +23,7 @@ rem %PERL% %PERL%\..\..\site\bin\pp --icon "..\resources\ddclient32.ico" -o ..\.
 rem %PERL% %PERL%\..\..\site\bin\pp --gui --icon "..\resources\ddclient32.ico" -o ..\..\..\target\ddclient-noconsole-noicon.exe ddclient
 
 echo Compiling ddclient.exe
-%PERL% %PERL%\..\..\site\bin\pp  --link %PERL%\..\..\..\c\bin\libssl-1_1-x64__.dll --link %PERL%\..\..\..\c\bin\zlib1__.dll --link %PERL%\..\..\..\c\bin\libcrypto-1_1-x64__.dll -o ..\..\..\target\ddclient-noicon.exe ddclient
+%PERL% %PERL%\..\..\site\bin\pp --module JSON::PP --link %PERL%\..\..\..\c\bin\libssl-1_1-x64__.dll --link %PERL%\..\..\..\c\bin\zlib1__.dll --link %PERL%\..\..\..\c\bin\libcrypto-1_1-x64__.dll -o ..\..\..\target\ddclient-noicon.exe ddclient
 
 rem win32::exe no longer works
 rem %PERL% -e "use Win32::Exe; $exe = Win32::Exe->new('..\..\..\target\ddclient.exe'); $exe->set_single_group_icon('..\resources\ddclient32.ico'); $exe->write;"


### PR DESCRIPTION
For me I want this so Gandi vendor code works.

It seems like there are a few optional requirements for this script:
IO::Socket::SSL
IO::Socket::INET6
Digest::SHA1 or Digest::SHA
JSON::PP
WWW::Curl::Easy

I do not know which of these can be (easily) included on windows... so I'm only adding JSON::PP for now.